### PR TITLE
update MSSM scripts

### DIFF
--- a/code/mssm.sh
+++ b/code/mssm.sh
@@ -32,6 +32,13 @@ nJOBS_2thick=$(( (nCPU/nPARALLEL_2thick)*nPARALLEL_2thick ))
 nJOBS_3GWR=$(( (nCPU/nPARALLEL_3GWR)*nPARALLEL_3GWR ))
 nJOBS_3thick=$(( (nCPU/nPARALLEL_3thick)*nPARALLEL_3thick ))
 
+# prevent zero-division error
+#if [ "$nJOBS_1" -eq 0 ]; then nJOBS_1=1; fi
+#if [ "$nJOBS_2GWR" -eq 0 ]; then nJOBS_2GWR=1; fi
+#if [ "$nJOBS_2thick" -eq 0 ]; then nJOBS_2thick=1; fi
+#if [ "$nJOBS_3GWR" -eq 0 ]; then nJOBS_3GWR=1; fi
+#if [ "$nJOBS_3thick" -eq 0 ]; then nJOBS_3thick=1; fi
+
 bash step1_generate_GM_WM_GWR.sh $SUBJECTS_DIR $nJOBS_1 $SUBSTRING && \
 bash step2_reg_surf2fsaverage_GWR.sh $SUBJECTS_DIR $nJOBS_2GWR $SUBSTRING && \
 bash step2_reg_surf2fsaverage_thickness.sh $SUBJECTS_DIR $nJOBS_2thick $SUBSTRING && \

--- a/code/step1_generate_GM_WM_GWR.sh
+++ b/code/step1_generate_GM_WM_GWR.sh
@@ -58,12 +58,12 @@ GWR(){
 
 # Create a sympolic link for fsaverage
 if [ ! -f $SUBJECTS_DIR/fsaverage ]; then
-    ln -s /autofs/cluster/freesurfer/centos7_x86_64/7.2.0/subjects/fsaverage $SUBJECTS_DIR
+    ln -s $FREESURFER_HOME/subjects/fsaverage $SUBJECTS_DIR
 fi
 
 # Create identity registration file for every subject (in parallel)
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do  # -I: exception
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do  # ^: exception
 
 if [[ $subj == $SUBSTRING ]]; then # optional
 
@@ -91,7 +91,7 @@ wait
 
 # Generate WM intensity surfaces for every subject
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do  # -I: exception
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do  # ^: exception
     
 if [[ $subj == $SUBSTRING ]]; then # optional
 
@@ -123,7 +123,7 @@ wait
 
 # Generate GM intensity surfaces for every subject
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do  # -I: exception
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do  # ^: exception
    
 if [[ $subj == $SUBSTRING ]]; then # optional
 
@@ -159,7 +159,7 @@ wait
 
 # Generate GWR maps for every subject
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do  # -I: exception
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do  # ^: exception
    
 if [[ $subj == $SUBSTRING ]]; then # optional
 

--- a/code/step2_reg_surf2fsaverage_GWR.sh
+++ b/code/step2_reg_surf2fsaverage_GWR.sh
@@ -35,7 +35,7 @@ register_GWR2fsaverage(){
 
 # Generate registered GWR,GM,WM maps for every subject - left hemi
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do
 
 if [[ $subj == $SUBSTRING ]]; then # optional
 
@@ -65,7 +65,7 @@ wait
 
 # Generate registered GWR,GM,WM maps for every subject - right hemi
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do
 
 if [[ $subj == $SUBSTRING ]]; then # optional
 

--- a/code/step2_reg_surf2fsaverage_thickness.sh
+++ b/code/step2_reg_surf2fsaverage_thickness.sh
@@ -27,7 +27,7 @@ register_CT2fsaverage(){
 
 # generate registered CT files for every subject (in parallel)
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do
 
 if [[ $subj == $SUBSTRING ]]; then # optional
 

--- a/code/step3_smooth_registered_GWR.sh
+++ b/code/step3_smooth_registered_GWR.sh
@@ -14,8 +14,8 @@
 SUBJECTS_DIR=$1
 N_JOBS=$2
 SUBSTRING=$3
+FWHM=$4
 CHECKLIST_GWR="files_to_check_GWR.txt"
-
 
 # Func1: smooth GWR,GM,WM maps that are already registered to fsaverage
 smooth(){
@@ -23,8 +23,8 @@ smooth(){
     for file in `ls $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage/*$1* | xargs -n 1 basename`; do
         mri_surf2surf   --s fsaverage \
                         --srcsurfval $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage/$file \
-                        --trgsurfval $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage_smoothed5mm/$file \
-                        --fwhm-trg 5 \
+                        --trgsurfval $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage_smoothed${FWHM}mm/$file \
+                        --fwhm-trg ${FWHM} \
                         --hemi "$1" &
     done
 }
@@ -34,13 +34,13 @@ smooth(){
 
 ## Generate smoothed GWR,GM,WM maps for lh (in parallel)
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do
 
 if [[ $subj == $SUBSTRING ]]; then # optional
 
     all_files_exist=1
     while read file; do
-        if [ ! -e $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage_smoothed5mm/$file ]; then
+        if [ ! -e $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage_smoothed${FWHM}mm/$file ]; then
             all_files_exist=$((all_files_exist*0))
         fi
     done < $CHECKLIST_GWR
@@ -49,7 +49,7 @@ if [[ $subj == $SUBSTRING ]]; then # optional
         echo "$subj: GWR/GM/WM maps are already smoothed."
     else
         echo "$subj: Spatially smoothing GWR/GM/WM maps (lh)."
-        mkdir -p $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage_smoothed5mm
+        mkdir -p $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage_smoothed${FWHM}mm
         smooth "lh"
         cnt=$((cnt+14))
     fi
@@ -64,13 +64,13 @@ wait
 
 ## Generate smoothed GWR,GM,WM maps for rh (in parallel)
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do
 
 if [[ $subj == $SUBSTRING ]]; then # optional
 
     all_files_exist=1
     while read file; do
-        if [ ! -e $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage_smoothed5mm/$file ]; then
+        if [ ! -e $SUBJECTS_DIR/$subj/mri/GWC/reg_surf2fsaverage_smoothed${FWHM}mm/$file ]; then
             all_files_exist=$((all_files_exist*0))
         fi
     done < $CHECKLIST_GWR

--- a/code/step3_smooth_registered_thickness.sh
+++ b/code/step3_smooth_registered_thickness.sh
@@ -14,7 +14,7 @@ SUBJECTS_DIR=$1
 N_JOBS=$2
 SUBSTRING=$3
 CHECKLIST_CT="files_to_check_thickness.txt"
-
+FWHM=$4
 
 # Func1: smooth CT maps that are already registered to fsaverage
 smooth(){
@@ -22,8 +22,8 @@ smooth(){
                     --src_type curv \
                     --trg_type curv \
                     --srcsurfval $SUBJECTS_DIR/$subj/surf/reg_surf2fsaverage/$1.thickness \
-                    --trgsurfval $SUBJECTS_DIR/$subj/surf/reg_surf2fsaverage_smoothed5mm/$1.thickness \
-                    --fwhm-trg 5 \
+                    --trgsurfval $SUBJECTS_DIR/$subj/surf/reg_surf2fsaverage_smoothed${FWHM}mm/$1.thickness \
+                    --fwhm-trg ${FWHM} \
                     --hemi $1
 }
 
@@ -32,13 +32,13 @@ smooth(){
 
 # generate smoothed CT maps (in parallel)
 cnt=0
-for subj in `ls $SUBJECTS_DIR -I fsaverage`; do
+for subj in $(ls $SUBJECTS_DIR | grep -v '^fsaverage$'); do
 
 if [[ $subj == $SUBSTRING ]]; then # optional
 
     all_files_exist=1
     while read file; do
-        if [ ! -e $SUBJECTS_DIR/$subj/surf/reg_surf2fsaverage_smoothed5mm/$file ]; then
+        if [ ! -e $SUBJECTS_DIR/$subj/surf/reg_surf2fsaverage_smoothed${FWHM}mm/$file ]; then
             all_files_exist=$((all_files_exist*0))
         fi
     done < $CHECKLIST_CT
@@ -47,7 +47,7 @@ if [[ $subj == $SUBSTRING ]]; then # optional
         echo "$subj: Cortical thickness maps are already smoothed."
     else
         echo "$subj: Spatially smoothing cortical thickness maps."
-        mkdir -p $SUBJECTS_DIR/$subj/surf/reg_surf2fsaverage_smoothed5mm
+        mkdir -p $SUBJECTS_DIR/$subj/surf/reg_surf2fsaverage_smoothed${FWHM}mm
         smooth "lh" &
         smooth "rh" &
         cnt=$((cnt+2))

--- a/code/step4_check_results.sh
+++ b/code/step4_check_results.sh
@@ -16,9 +16,9 @@ CHECKLIST_GWR="files_to_check_GWR.txt"
 CHECKLIST_CT="files_to_check_thickness.txt"
 
 if [ "$SUBSTRING" == "*" ]; then
-    n_SUBJ=`ls -1 $SUBJECTS_DIR -I fsaverage | tr '\n' '\0' | xargs -0 -n 1 basename | wc -l`
+    n_SUBJ=`ls $SUBJECTS_DIR | grep -v '^fsaverage$' | tr '\n' '\0' | xargs -0 -n 1 basename | wc -l`
 else
-    n_SUBJ=`ls -ld $SUBJECTS_DIR/$SUBSTRING | wc -l`
+    n_SUBJ=`ls $SUBJECTS_DIR | grep -v '^fsaverage$' | wc -l`
 fi
 
 n_GWR=`wc -l < $CHECKLIST_GWR`


### PR DESCRIPTION
The updated script works well on both MACOS and Linux.
Modified to set the path based on environment variables.
FWHM has been modified to apply the entered value instead of fixing it to 5.
Zero-division errors occurred, so I wrote code to prevent it, but there was a problem that ruined script parallelization in low-performance environments, so it only added as a comment.